### PR TITLE
Adding resampleImageToTarget

### DIFF
--- a/R/mrvnrfs.R
+++ b/R/mrvnrfs.R
@@ -5,17 +5,18 @@
 #'
 #' @param y list of training labels. either an image or numeric value
 #' @param x a list of lists where each list contains feature images
-#' @param labelmasks a list of masks where each mask defines the image space
-#' for the given list. that is, the nth mask indexes the nth feature set.
+#' @param labelmask a mask for the features (all in the same image space)
+#' the labelmask defines the number of parallel samples that will be used
+#' per subject sample. two labels will double the number of predictors
+#' contributed from each feature image.
 #' @param rad vector of dimensionality d define nhood radius
 #' @param nsamples (per subject to enter training)
 #' @param ntrees (for the random forest model)
 #' @param multiResSchedule an integer vector defining multi-res levels
 #' @param asFactors boolean - treat the y entries as factors
-#' @param voxchunk split up prediction by this number of voxels per chunk
 #' @return list a 4-list with the rf model, training vector, feature matrix
 #' and the random mask
-#' @author Avants BB, Tustison NJ
+#' @author Avants BB, Tustison NJ, Pustina D
 #'
 #' @examples
 #'
@@ -24,7 +25,6 @@
 #' mask[ 5, 5:6]<-2
 #' ilist<-list()
 #' lablist<-list()
-#' masklist<-list()
 #' inds<-1:50
 #' scl<-0.33 # a noise parameter
 #' for ( predtype in c("label","scalar") )
@@ -45,157 +45,87 @@
 #'       }
 #'     ilist[[i]]<-list(img,imgb)  # two features
 #'     lablist[[i]]<-limg
-#'     masklist[[i]] = mask
 #'   }
 #' rad<-rep( 1, 2 )
 #' mr <- c(1.5,1)
-#' rfm<-mrvnrfs( lablist , ilist, masklist, rad=rad, multiResSchedule=mr,
+#' rfm<-mrvnrfs( lablist , ilist, mask, rad=rad, multiResSchedule=mr,
 #'      asFactors = (  predtype == "label" ) )
 #' rfmresult<-mrvnrfs.predict( rfm$rflist,
-#'      ilist, masklist, rad=rad, asFactors=(  predtype == "label" ),
+#'      ilist, mask, rad=rad, asFactors=(  predtype == "label" ),
 #'      multiResSchedule=mr )
 #' if ( predtype == "scalar" )
-#'   print( cor( unlist(lablist) , unlist(rfmresult$seg) ) )
+#'   print( cor( unlist(lablist) , rfmresult$seg ) )
 #' } # end predtype loop
 #'
-#' \dontrun{
-#' myop="GD" # try "Laplacian" or "Grad"
-#' myop="Laplacian"
-#' myop="Grad"
-#' img = antsImageRead( getANTsRData("r16") )
-#' mask = getMask( img )
-#' grad = iMath(img,myop,1,1)
-#' predimglist = list( grad )
-#' featimglist = list( list( img ) )
-#' masklist = list( mask )
-#' mr <- c(4,2,1)
-#' rad=c(2,2)
-#' vwout = mrvnrfs( predimglist , featimglist, masklist,
-#'   rad=rad, nsamples = 2000, multiResSchedule=mr, ntrees=1000,
-#'   asFactors=FALSE )
-#'
-#' img = antsImageRead( getANTsRData("r64") )
-#' mask = getMask( img )
-#' predimglist = list( grad )
-#' featimglist = list( list( img ) )
-#' masklist = list( mask )
-#' rfmresult<-mrvnrfs.predict( vwout$rflist, featimglist, masklist,
-#'   rad=rad, multiResSchedule=mr,
-#'   asFactors=FALSE )
-#' gtr = iMath(img,myop,1,1)*mask # ground truth
-#' plot( gtr )
-#' dev.new()
-#' plot( rfmresult$probs[[1]][[1]]*mask )
-#' print( cor( rfmresult$probs[[1]][[1]][mask==1], gtr[mask==1] ))
-#' }
 #'
 #' @export mrvnrfs
 mrvnrfs <- function( y, x, labelmasks, rad=NA, nsamples=1,
-  ntrees=500, multiResSchedule=c(4,2,1), asFactors=TRUE, voxchunk=1000 ) {
-    # check y type
-    yisimg<-TRUE
-    useFirstMask=FALSE
-    if ( typeof(labelmasks) != "list" ) {
-      inmask = antsImageClone( labelmasks )
-      labelmasks=list()
-      for ( i in 1:length(x) ) labelmasks[[i]] = inmask
-      useFirstMask = TRUE
+                     ntrees=500, multiResSchedule=c(4,2,1), asFactors=TRUE,
+                     voxchunk=50000) {
+  
+  # check if Y is antsImage or a number
+  yisimg<-TRUE
+  if ( typeof(y[[1]]) == "integer" | typeof(y[[1]]) == "double") yisimg<-FALSE
+  rflist<-list()
+  rfct<-1
+  
+  # for a single labelmask create a list with it
+  useFirstMask=FALSE
+  if ( typeof(labelmasks) != "list" ) {
+    inmask = antsImageClone( labelmasks )
+    labelmasks=list()
+    for ( i in 1:length(x) ) labelmasks[[i]] = inmask
+    useFirstMask = TRUE
+  }
+  
+  # loop of resolutions
+  mrcount=0
+  for ( mr in multiResSchedule ) {
+    mrcount=mrcount+1
+    message(paste(mrcount,'of',length(multiResSchedule)))
+    
+    invisible(gc())
+    
+    # add newprobs from previous run, already correct dimension
+    if ( rfct > 1 ) {
+      for ( kk in 1:length(x) ) {
+        p1<-unlist( x[[kk]] )
+        p2<-unlist(newprobs[[kk]])
+        temp<-lappend(  p1 ,  p2  )
+        x[[kk]]<-temp
+      }
+      rm(newprobs); invisible(gc())
     }
-    if ( typeof(y[[1]]) == "integer" | typeof(y[[1]]) == "double") yisimg<-FALSE
-    rflist<-list()
-    rfct<-1
-    newprobs<-list()
-    for ( mr in multiResSchedule )
-      {
-      submasks = list()
-      for ( i in 1:length(labelmasks) )
-        {
-        subdim<-round( dim( labelmasks[[i]] ) / mr )
-        subdim[ subdim < 2*rad+1 ] <- ( 2*rad+1 )[  subdim < 2*rad+1 ]
-        submask<-resampleImage( labelmasks[[i]], subdim, useVoxels=1,
-          interpType=as.numeric(asFactors) )
-        submasks[[i]]=submask
-        }
-      ysub<-y
-      if ( yisimg )
-      {
-      for ( i in 1:(length(y)) )
-        {
-        subdim<-dim( submasks[[i]] )
-        ysub[[i]]<-resampleImage( y[[i]], subdim, useVoxels=1,
-          interpType=as.numeric(asFactors) ) # might be labels
-        }
-      }
-      xsub<-x
-      if ( rfct > 1 )
-        {
-        for ( kk in 1:length(xsub) )
-          {
-          p1<-unlist( xsub[[kk]] )
-          p2<-unlist(newprobs[[kk]])
-          temp<-lappend(  p1 ,  p2  )
-          xsub[[kk]]<-temp
-          }
-        }
-      for (  i in 1:length(xsub) )
-        for ( j in 1:length(xsub[[i]]))
-          {
-          subdim<-dim( submasks[[i]] )
-          xsub[[i]][[j]] =
-            resampleImage( xsub[[i]][[j]], subdim, useVoxels=1,
-               interpType=as.numeric(asFactors) ) # might be labels
-          }
-      if ( ! useFirstMask )
-        sol<-vwnrfs( ysub, xsub, submasks,
-          rad, nsamples, ntrees, asFactors )
-      if ( useFirstMask )
-        sol<-vwnrfs( ysub, xsub, submasks[[1]],
-          rad, nsamples, ntrees, asFactors )
-      nfeats<-length(xsub[[1]])
-      predtype<-'response'
-      if ( asFactors ) predtype<-'prob'
-      for ( i in 1:(length(xsub)) )
-        {
-        splitter = round( sum(  submasks[[i]] / voxchunk ) )
-        if ( splitter <= 2 ) splitter=1
-        subsubmask = splitMask( submasks[[i]] , splitter )
-        for ( sp in 1:splitter )
-          {
-          locmask = thresholdImage( subsubmask, sp, sp )
-          m1<-t(getNeighborhoodInMask( xsub[[i]][[1]], locmask,
-            rad, spatial.info=F, boundary.condition='image' ))
-          if ( nfeats > 1 )
-          for ( k in 2:nfeats )
-            {
-            m2<-t(getNeighborhoodInMask( xsub[[i]][[k]], locmask,
-                rad, spatial.info=F, boundary.condition='image' ))
-            m1<-cbind( m1, m2 )
-            }
-          subprobsrf<-t(
-            predict( sol$rfm, newdata=m1, type=predtype ) )
-          if ( sp == 1 )
-            {
-            probsrf = subprobsrf
-            } else {
-              probsrf = cbind( probsrf, subprobsrf )
-            }
-          }
-      if ( asFactors )
-        probsx<-matrixToImages(probsrf,  submasks[[i]] )
-      else probsx<-list(
-        makeImage( submasks[[i]], probsrf ) )
-      for ( temp in 1:length(probsx) )
-        {
-        if ( !all( dim( probsx[[temp]] ) == dim(labelmasks[[i]]) ) )
-          probsx[[temp]]<-resampleImage( probsx[[temp]],
-            dim(labelmasks[[i]]), useVoxels=1, 0 )
-        }
-      newprobs[[i]]<-probsx
-      }
+    
+    invisible(gc())
+    
+    # build model for this mr
+    if (!useFirstMask) sol<-vwnrfs( y, x, labelmasks, rad, nsamples, ntrees, asFactors, reduceFactor = mr )
+    if (useFirstMask)  sol<-vwnrfs( y, x, labelmasks[[1]], rad, nsamples, ntrees, asFactors, reduceFactor = mr )
+    
+    sol$fm = sol$tv = sol$randmask = NULL
+    
+    invisible(gc())
+    
+    # if not last mr, predict new features for next round
+    if (mrcount < length(multiResSchedule)) {
+      predme = vwnrfs.predict(rfm=sol$rfm, x=x, labelmasks=labelmasks,
+                          rad=rad, asFactors=TRUE, voxchunk=voxchunk,
+                            reduceFactor = mr)
+   
+      newprobs=predme$probs
+      rm(predme); invisible(gc())
+      for ( tt1 in 1:length(newprobs) )
+        for (tt2 in 1:length(newprobs[[tt1]]))
+          newprobs[[tt1]][[tt2]]<-resampleImage( newprobs[[tt1]][[tt2]], dim(labelmasks[[tt1]]), useVoxels=1, 0 )
+    }
+    
+    invisible(gc())
     rflist[[rfct]]<-sol$rfm
     rfct<-rfct+1
-    } # mr loop
-    return( list(rflist=rflist, probs=newprobs, randmask=sol$randmask ) )
+  } # mr loop
+  
+  return( list(rflist=rflist) )
 }
 
 
@@ -207,146 +137,61 @@ mrvnrfs <- function( y, x, labelmasks, rad=NA, nsamples=1,
 #'
 #' @param rflist a list of random forest models from mrvnrfs
 #' @param x a list of lists where each list contains feature images
-#' @param labelmasks a list of masks where each mask defines the image space
-#' for the given list. that is, the nth mask indexes the nth feature set.
+#' @param labelmask a mask for the features (all in the same image space)
 #' @param rad vector of dimensionality d define nhood radius
 #' @param multiResSchedule an integer vector defining multi-res levels
 #' @param asFactors boolean - treat the y entries as factors
-#' @param voxchunk split up prediction by this number of voxels per chunk
 #' @return list a 4-list with the rf model, training vector, feature matrix
 #' and the random mask
-#' @author Avants BB, Tustison NJ
+#' @author Avants BB, Tustison NJ, Pustina D
 #'
 #' @export mrvnrfs.predict
-mrvnrfs.predict <- function( rflist, x,
-  labelmasks,
-  rad=NA,
-  multiResSchedule=c(4,2,1),
-  asFactors=TRUE, voxchunk=1000 )
-  {
-    if ( typeof(labelmasks) != "list" ) {
-      inmask = antsImageClone( labelmasks )
-      labelmasks=list()
-      for ( i in 1:length(x) ) labelmasks[[i]] = inmask
-    }
-    rfct<-1
-    predtype<-'response'
-    if ( asFactors ) predtype<-'prob'
-    newprobs = list()
-    for ( mr in multiResSchedule )
-      {
-      newsegs = list()
-      submasks = list()
-      for ( i in 1:length(labelmasks) )
-        {
-        subdim<-round( dim( labelmasks[[i]] ) / mr )
-        subdim[ subdim < 2*rad+1 ] <- ( 2*rad+1 )[  subdim < 2*rad+1 ]
-        submask<-resampleImage( labelmasks[[i]], subdim, useVoxels=1,
-          interpType=as.numeric(asFactors) )
-        submasks[[i]]=submask
-        }
-      xsub<-x
-      if ( rfct > 1 )
-        {
-        for ( kk in 1:length(xsub) )
-          {
-          temp<-lappend(  unlist( xsub[[kk]] ) ,
-            unlist(newprobs[[kk]])  )
-          xsub[[kk]]<-temp
-          }
-        }
-      nfeats<-length(xsub[[1]])
-      for ( i in 1:(length(x)) )
-        {
-        subdim = dim( submasks[[i]] )
-        xsub[[i]][[1]]<-resampleImage(
-          xsub[[i]][[1]], subdim, useVoxels=1, 0 )
-        splitter = round( sum(  submasks[[i]] / voxchunk ) )
-        if ( splitter <= 2 ) splitter=1
-        subsubmask = splitMask( submasks[[i]] , splitter )
-        for ( sp in 1:splitter )
-          {
-          locmask = thresholdImage( subsubmask, sp, sp )
-          m1<-t(getNeighborhoodInMask( xsub[[i]][[1]], locmask,
-            rad, spatial.info=F, boundary.condition='image' ))
-          if ( nfeats > 1 )
-          for ( k in 2:nfeats )
-            {
-            xsub[[i]][[k]]<-resampleImage( xsub[[i]][[k]], subdim,
-                useVoxels=1, 0 )
-            m2<-t(getNeighborhoodInMask( xsub[[i]][[k]], locmask,
-                rad, spatial.info=F, boundary.condition='image' ))
-            m1<-cbind( m1, m2 )
-            }
-          subprobsrf<-t(
-            predict( rflist[[rfct]], newdata=m1, type=predtype ) )
-          if ( sp == 1 )
-            {
-            probsrf = subprobsrf
-            } else {
-              probsrf = cbind( probsrf, subprobsrf )
-            }
-          }
-      if ( asFactors )
-        probsx<-matrixToImages(probsrf,  submasks[[i]] )
-      else probsx<-list(
-        makeImage( submasks[[i]], probsrf ) )
-      for ( temp in 1:length(probsx) )
-        {
-        if ( !all( dim( probsx[[temp]] ) == dim(labelmasks[[i]]) ) )
-          probsx[[temp]]<-resampleImage( probsx[[temp]],
-            dim(labelmasks[[i]]), useVoxels=1, 0 )
-        }
-      if ( asFactors )
-      {
-      rfseg<-imageListToMatrix( unlist(probsx) , labelmasks[[i]] )
-      rfseg<-apply( rfseg, FUN=which.max, MARGIN=2 )
-      newsegs[[i]] = makeImage( submasks[[i]], rfseg )
-      } else newsegs[[i]] = median( probsrf )
-      newprobs[[i]]<-probsx
+mrvnrfs.predict <- function( rflist, x, labelmasks, rad=NA,
+                             multiResSchedule=c(4,2,1), asFactors=TRUE,
+                             voxchunk=60000) {
+  if ( ! usePkg("randomForest") )
+    stop("Please install the randomForest package, example: install.packages('randomForest')")
+  
+  
+  # for a single labelmask create a list the same
+  useFirstMask=FALSE
+  if ( typeof(labelmasks) != "list" ) {
+    inmask = antsImageClone( labelmasks )
+    labelmasks=list()
+    for ( i in 1:length(x) ) labelmasks[[i]] = inmask
+    useFirstMask = TRUE
+  }
+  
+  predtype<-'response'
+  if ( asFactors ) predtype<-'prob'
+  
+  rfct<-1
+  for ( mr in multiResSchedule ){
+
+    if ( rfct > 1 ) {
+      for ( kk in 1:length(x) ) {
+        p1<-unlist( x[[kk]] )
+        p2<-unlist(newprobs[[kk]])
+        temp<-lappend(  p1 ,  p2  )
+        x[[kk]]<-temp
       }
+      rm(newprobs); invisible(gc())
+    }
+    
+    
+    predme = vwnrfs.predict(rflist[[rfct]], x=x, labelmasks=labelmasks,
+                              rad=rad, asFactors=TRUE, voxchunk=voxchunk,
+                              reduceFactor = mr)
+
+    newprobs = predme$probs
+    newseg = predme$seg
+    if (rfct < length(multiResSchedule)) {
+      for ( tt1 in 1:length(newprobs) )
+        for (tt2 in 1:length(newprobs[[tt1]]))
+          newprobs[[tt1]][[tt2]]<-resampleImage( newprobs[[tt1]][[tt2]], dim(labelmasks[[1]]), useVoxels=1, 0 )
+    }
+    
     rfct<-rfct+1
-    } # mr loop
-    return( list( seg=newsegs, probs=newprobs) )
-}
-
-
-
-#' split a mask into n labeled sub-masks
-#'
-#' @param mask antsImage mask
-#' @param n number of mask chunks
-#' @return relabeledMask
-#' @author Avants BB, Tustison NJ
-#'
-#' @examples
-#' mask = getMask( antsImageRead( getANTsRData("r16" ) ) )
-#' smask = splitMask( mask, 10 )
-#'
-#' @export splitMask
-splitMask <- function( mask, n )
-{
-# first compute chunk size
-  hasvalues = mask >= 0.5
-  nnz = sum( hasvalues )
-  voxchunk = round( nnz / n ) - 1
-  chunk.seq = seq(1, nnz, by=voxchunk )
-  chunk.seq[ length(chunk.seq) ] = nnz
-  smask = mask * 0
-  for ( ch in 1:( length(chunk.seq)-1 ) )
-    {
-    # set end of this chunk
-    chnxt = chunk.seq[ ch + 1 ] - 1
-    if ( ch ==  ( length(chunk.seq)-1 ) ) chnxt = nnz
-    # create mask for this chunk
-    temp = which( hasvalues, arr.ind=T )[ chunk.seq[ch]:chnxt ]
-    tnnz = hasvalues
-    tnnz[ -temp ] = FALSE
-    smask[ tnnz ] = ch
-    }
-  if ( sum( mask >= 0.5 ) != sum(smask >= 0.5 ) )
-    {
-    stop("submask non-zero entries should be the same as input mask" )
-    }
-  return( smask )
+  } # mr loop
+  return(list(seg=newseg, probs=newprobs))
 }

--- a/R/randomMask.R
+++ b/R/randomMask.R
@@ -1,0 +1,44 @@
+#' Get a random mask
+#'
+#' Get a mask with a specific number of voxels randomly
+#' distributed on the input image/mask
+#' 
+#' @param img an antsImage, either continuous or mask-like. This will
+#' define the space where to sample voxels from. If this image is
+#' continous (i.e., a T1), voxels will be sampled from all nonzero
+#' voxels.
+#' @param nsamples the number of random voxels to select from
+#' @param perLabel logical, if true the input image must be multi-label
+#' and the the output will have nsamples from each label (i.e., 200
+#' samples from each label) 
+#' 
+#' @return binary antsImage with random voxels set to 1
+#' 
+#' @author Pustina D
+#' 
+#' @examples
+#' 
+#' img<-antsImageRead( getANTsRData("r16"))
+#' randmask<-randomMask(img,200)
+#'
+#'@export randomMask
+
+randomMask = function(img, nsamples, perLabel=F) {
+  randmask = img*0 # set empty output image
+  
+  # img can be continuous, search mask is all non zeros
+  if (perLabel == F) img[ img!=0 ] = 1
+  
+  # get label vector except 0
+  ulabs<-sort( unique( c( as.numeric( img ) ) ) )
+  ulabs<-ulabs[ ulabs > 0 ]
+  
+  for ( ulab in ulabs ) {
+    ulabvec<-( img == as.numeric( ulab ) ) # logical of this label
+    n<-sum( ulabvec == TRUE ) # total available voxels for label
+    k<-min( c( nsamples, n ) ) # reduce nsample if not enough voxels
+    ulabvec[ -(sample(which(ulabvec==T), k)) ] = F # k random voxels from ulabvec
+    randmask[ulabvec] = 1
+  }
+  return(randmask)
+}

--- a/R/resampleImageToTarget.R
+++ b/R/resampleImageToTarget.R
@@ -11,11 +11,12 @@
 #' @examples
 #'
 #' fi<-antsImageRead( getANTsRData("r16"))
-#' finn<-resampleImage(fi,c(50,60),1,0)
-#' filin<-resampleImage(fi,c(1.5,1.5),0,1)
+#' fi.ref<-antsImageRead( getANTsRData("r64"))
+#' fi <- resampleImage(fi, c(2.2, 2.2, 2.2), useVoxels = 0, interpType = 1)
+#' finew <- resampleImageToTarget(fi, fi.ref)
 #'
-#' @export resampleImage
-resampleImage <- function(image, target, interpType = 1) {
+#' @export resampleImageToTarget
+resampleImageToTarget <- function(image, target, interpType = 1) {
   inimg <- antsImageClone(image, "double")
   outimg <- antsImageClone(image, "double")
   rsampar <- paste(dim(target), collapse = "x")

--- a/R/resampleImageToTarget.R
+++ b/R/resampleImageToTarget.R
@@ -1,0 +1,30 @@
+#' resampleImageToTarget
+#'
+#' Resample image by using another image as target reference.
+#'
+#' @param image input antsImage matrix
+#' @param resampleParams vector of size dimension with numeric values
+#' @param useVoxels true means interpret resample params as voxel counts
+#' @param interpType one of 0 (linear), 1 (nearest neighbor),
+#'   2 (gaussian), 3 (windowed sinc), 4 (bspline)
+#' @return output antsImage
+#' @author Avants BB
+#' @examples
+#'
+#' fi<-antsImageRead( getANTsRData("r16"))
+#' finn<-resampleImage(fi,c(50,60),1,0)
+#' filin<-resampleImage(fi,c(1.5,1.5),0,1)
+#'
+#' @export resampleImage
+resampleImage <- function(image, target, interpType = 1) {
+  inimg <- antsImageClone(image, "double")
+  outimg <- antsImageClone(image, "double")
+  rsampar <- paste(dim(target), collapse = "x")
+  useVoxels <- 1
+  args <- list(image@dimension, inimg, outimg, rsampar, useVoxels, interpType)
+  k <- .int_antsProcessArguments(args)
+  retval <- .Call("ResampleImage", k)
+  outimg <- antsImageClone(outimg, image@pixeltype)
+  outimg <- antsCopyImageInfo(target, outimg)
+  return(outimg)
+}

--- a/R/resampleImageToTarget.R
+++ b/R/resampleImageToTarget.R
@@ -3,12 +3,11 @@
 #' Resample image by using another image as target reference.
 #'
 #' @param image input antsImage matrix
-#' @param resampleParams vector of size dimension with numeric values
-#' @param useVoxels true means interpret resample params as voxel counts
+#' @param target reference image to use for voxel size and header info
 #' @param interpType one of 0 (linear), 1 (nearest neighbor),
 #'   2 (gaussian), 3 (windowed sinc), 4 (bspline)
 #' @return output antsImage
-#' @author Avants BB
+#' @author Pustina D
 #' @examples
 #'
 #' fi<-antsImageRead( getANTsRData("r16"))

--- a/R/vwnrfs.R
+++ b/R/vwnrfs.R
@@ -57,7 +57,12 @@
 #'
 #' @export vwnrfs
 vwnrfs <- function( y, x, labelmasks, rad=NA, nsamples=8,
-  ntrees=500, asFactors=TRUE ) {
+                    ntrees=500, asFactors=TRUE, reduceFactor=1) {
+  
+  if ( ! usePkg("randomForest") )
+    stop("Please install the randomForest package, example: install.packages('randomForest')")
+ 
+  # one labelmask or many
   useFirstMask=FALSE
   if ( typeof(labelmasks) != "list" ) {
     inmask = antsImageClone( labelmasks )
@@ -65,98 +70,284 @@ vwnrfs <- function( y, x, labelmasks, rad=NA, nsamples=8,
     for ( i in 1:length(x) ) labelmasks[[i]] = inmask
     useFirstMask = TRUE
   }
-  if ( all( is.na( rad )  ) ) {
-    rad<-rep(0, x[[1]][[1]]@dimension )
-  }
+  
+  # set rad=0 if not defined
+  if ( all( is.na( rad )  ) ) rad<-rep(0, x[[1]][[1]]@dimension )
+  
   # check y type
   yisimg<-TRUE
   if (  typeof(y[[1]]) == "integer" | typeof(y[[1]]) == "double" ) yisimg<-FALSE
+  
   idim<-length(rad)
   if ( idim != x[[1]][[1]]@dimension )
     stop("vwnrfs: dimensionality does not match")
-  # first thing - find unique labels
+  
+  invisible(gc())
+
+  # initialize fm and tv to maximum potential size
   ulabs<-sort( unique( c( as.numeric( labelmasks[[1]] ) ) ) )
   ulabs<-ulabs[ ulabs > 0 ]
-  # second thing - create samples for each unique label
-  randmask<-antsImageClone( labelmasks[[1]] )*0
-  for ( ulab in ulabs )
-    {
-    ulabvec<-( labelmasks[[1]] == as.numeric( ulab ) )
-    randvec<-rep( FALSE, length( ulabvec ) )
-    k<-min( c( nsamples, sum(ulabvec == TRUE) ) )
-    n<-sum( ulabvec == TRUE )
-    randvec[ ulabvec == TRUE ][ sample(1:n)[1:k] ]<-TRUE
-    randmask[ randvec ]<-ulab
+  neigh = prod(rad*2+1) # neighborhood size we'll get from getNeighborhoodInMask
+  nsubj = length(x) # number of subjects
+  nfeats = nfeats<-length(x[[1]]) # number of features
+  tv<-rep( NA, nsamples*length(ulabs)*nsubj )  # Y for random forest
+  fm = matrix(nrow=length(tv) ,  ncol=neigh*nfeats )  # X for random forest
+  
+  # fill tv and fm
+  fromrow = torow =  0
+  for ( i in 1:nsubj) {
+    
+    xfactor = x[[i]]
+    if (yisimg) { yfactor = y[[i]] 
+    } else { yfactor = y[i] }
+    labmaskfactor = antsImageClone(labelmasks[[i]])
+    
+    # resample subject images with provided factor
+    if (reduceFactor != 1) {
+      subdim<-round( dim(labelmasks[[i]]) / reduceFactor )
+      subdim[ subdim < 2*rad+1 ] <- ( 2*rad+1 )[  subdim < 2*rad+1 ]
+      if (yisimg) yfactor<-resampleImage( y[[i]], subdim, useVoxels=1, interpType=as.numeric(asFactors) )
+      for ( k in 1:nfeats ) xfactor[[k]]<-resampleImage( xfactor[[k]], subdim, useVoxels=1, 0 )
+      if (i==1 | useFirstMask==F) 
+        labmaskfactor = resampleImage(labmaskfactor, subdim, useVoxels=1,
+                                     interpType=as.numeric(asFactors) ) 
+    }      
+      
+      
+    # get randmask, only once unless necessary
+    if (i==1 | useFirstMask==F) {
+      randmask = randomMask(labmaskfactor,nsamples=nsamples,perLabel=T)
+      randvox = sum(randmask==1)
+      if ( randvox == 0 ) stop("error in input data - randmask ", i," is empty")
     }
-  # third thing - at each sample, find the training label/value
-  # and the features at that location - go subject by subject
-  # 3.1 first define the training vector
-  # NOTE: should find the same values in each image
-  rmsz<-sum( randmask > 0 ) # entries in mask
-  tv<-rep( NA, length(y)*rmsz )
-  seqby<-seq.int( 1, length(tv)+1, by=rmsz )
-  nfeats<-length(x[[1]])
-  testmat<-getNeighborhoodInMask( image=randmask, mask=randmask,
-    radius=rad, spatial.info=F, boundary.condition='image' )
-  testmat<-t( testmat )
-  hdsz<-nrow(testmat) # neighborhood size
-  nent<-nfeats*ncol(testmat)*nrow(testmat)*length(x)
-  masksizesum = sum( randmask > 0 )
-  fm<-matrix( nrow=( masksizesum*length(x)) ,  ncol=ncol(testmat)*nfeats  )
-  for ( i in 1:(length(y)) )
-    {
-    if ( !useFirstMask )
-    {
-    # get locally appropriate randmask
-    randmask<-antsImageClone( labelmasks[[i]] )*0
-    for ( ulab in ulabs )
-      {
-      ulabvec<-( labelmasks[[i]] == as.numeric( ulab ) )
-      randvec<-rep( FALSE, length( ulabvec ) )
-      k<-min( c( nsamples, sum(ulabvec == TRUE) ) )
-      n<-sum( ulabvec == TRUE )
-      randvec[ ulabvec == TRUE ][ sample(1:n)[1:k] ]<-TRUE
-      randmask[ randvec ]<-ulab
-      }
+    
+    # which rows shall we fill
+    fromrow = torow+1
+    torow = fromrow + randvox - 1
+    
+    # fill tv
+    if ( yisimg ) { 
+      tv[ fromrow:torow ] = t(getNeighborhoodInMask( yfactor, randmask, rad*0, spatial.info=F, boundary.condition='image' ))
+    } else { 
+      tv[ fromrow:torow ] = rep( yfactor, randvox ) 
     }
-    if ( sum(randmask > 0 ) == 0 )
-      {
-      stop("error in input data - mask ", i," is empty")
-      }
-    # ok ...
-    m1<-t(getNeighborhoodInMask( x[[i]][[1]], randmask,
-      rad, spatial.info=F, boundary.condition='image' ))
-    if ( nfeats > 1 )
-    for ( k in 2:nfeats )
-      {
-      m2<-t(getNeighborhoodInMask( x[[i]][[k]], randmask,
-          rad, spatial.info=F, boundary.condition='image' ))
-      m1<-cbind( m1, m2 )
-      }
-    nxt<-seqby[ i + 1 ]-1
-    if ( nrow(m1) != length(seqby[i]:nxt) )
-      {
-      ermsg=paste(
-        "The nsamples you chose is too large for the input images.",
-        "Perhaps try using a binary mask or reduce nsamples.")
-      stop( ermsg )
-      }
-    fm[ seqby[i]:nxt, ]<-m1
-    if ( yisimg )
-      tv[ seqby[i]:nxt ]<-y[[i]][ randmask > 0 ]
-    else tv[ seqby[i]:nxt ]<-rep( y[[i]], rmsz )
+    
+    fromcol = tocol = 0 # columns need reset for nfeats loop
+    for ( k in 1:nfeats ) {
+      # which columns shall we fill
+      fromcol = tocol+1
+      tocol = fromcol + neigh - 1
+      
+      # get neighborhood
+      m1<-t(getNeighborhoodInMask( xfactor[[k]], randmask, rad, spatial.info=F, boundary.condition='image' ))
+      
+      # make sure neiborhood is not out of image
+      if (any(is.na(m1)))
+        stop(paste('Neighborhood falling out of image for subject',i,'feature',k,'\n',
+                   'Consider zero-padding images to increase neighborhood availability.'))
+      
+      # put in fm
+      fm[fromrow:torow, fromcol:tocol] = m1
+      
+      invisible(gc())
     }
+  }
+  
+  invisible(gc())
+
+  # prune tv and fm to non-NA rows
+  fm = fm[!is.na(tv),]
+  tv = tv[!is.na(tv)]
   if ( asFactors ) tv<-factor( tv )
-  if ( usePkg("randomForest") )
-    {
-    rfm <- randomForest::randomForest(y=tv,x=fm, ntree = ntrees,
-      importance = FALSE, proximity = FALSE, keep.inbag = FALSE,
-      keep.forest = TRUE , na.action = na.omit, norm.votes=FALSE )
-    # need the forest for prediction
-    return( list(rfm=rfm, tv=tv, fm=fm, randmask=randmask ) )
+  
+  invisible(gc())
+
+  rfm <- randomForest::randomForest(y=tv,x=fm, ntree = ntrees,
+                                    importance = FALSE, proximity = FALSE, keep.inbag = FALSE,
+                                    keep.forest = TRUE , na.action = na.omit, norm.votes=FALSE )
+
+  invisible(gc())
+  return( list(rfm=rfm, tv=tv, fm=fm, randmask=randmask ) )
+}
+
+
+
+
+
+
+#' voxelwise neighborhood random forest prediction
+#'
+#' Takes a model created with vwnrfs and builds a prediction
+#' based on similar features used to train vwnrfs
+#'
+#' @param rfm random forest model trained with vwnrfs with certain 
+#' number of features.
+#' @param x a list of lists. Each list contains the list of feature
+#' images required to predict a response or an image. The features
+#' must be the same used during training. I.e., if you train on
+#' T1 and T2 images, those should be the same features used for
+#' prediction, in the same exact order for each subject.
+#' @param labelmasks a list of masks where each mask defines the space 
+#' to predict from. These can be individual masks for each subject 
+#' (i.e., custom brain masks) or a single antsImage that will be used
+#' for all subjects.
+#' @param rad vector of dimensionality d define the neighborhood radius.
+#' Must be the same radius with which the model was trained, i.e.,
+#' c(1,1,1)
+#' @param asFactors boolean - treat the y entries as factors. If this is
+#' true, the prediction will be a classification, and the output will
+#' produce images. If this is false, the prediction will be a regression, 
+#' and the output will produce a single response value.
+#' @return list a 2-list with the rf model, training vector, feature matrix
+#' and the random mask
+#' @author Pustina D
+#'
+#' @examples
+#' ## Do not run
+#' ## vwnrfs.predict(rfm, x=x, labelmasks=labelmasks,
+#' ## rad=rad, asFactors=TRUE, voxchunk=voxchunk,
+#' ## reduceFactor = mr)mask<-makeImage( c(10,10), 0 )
+#' ## End do not run
+#'
+#' @export vwnrfs.predict
+vwnrfs.predict = function(rfm, x, labelmasks, rad=NA, 
+                          asFactors=TRUE, voxchunk=30000, 
+                          reduceFactor = 1) {
+  
+  if ( ! usePkg("randomForest") )
+    stop("Please install the randomForest package, example: install.packages('randomForest')")
+  
+  # one labelmask or many
+  if ( typeof(labelmasks) != "list" ) {
+    inmask = antsImageClone( labelmasks )
+    labelmasks=list()
+    for ( i in 1:length(x) ) labelmasks[[i]] = inmask
+  } 
+  
+  neigh = prod(rad*2+1) # neighborhood size we'd get from getNeighborhoodInMask
+  nsubj = length(x) # number of subjects
+  nfeats = length(x[[1]]) # number of features
+  masterprobs = list()  # this will have posterior probabilities
+  if (asFactors) seg = list()  # this will have segmentations
+  if (!asFactors) response = rep(NA, nsubj)  # or responses
+  
+  # predict each subject individually
+  for(i in 1:nsubj) {
+
+    xfactor = x[[i]]
+    labmaskfactor = antsImageClone(labelmasks[[i]])
+    
+    # resample subject images with provided factor
+    if (reduceFactor != 1) {
+      subdim = round( dim(labmaskfactor) / reduceFactor )
+      subdim[ subdim < 2*rad+1 ] <- ( 2*rad+1 )[  subdim < 2*rad+1 ]
+      for ( k in 1:nfeats ) xfactor[[k]]<-resampleImage( xfactor[[k]], subdim, useVoxels=1, 0 )
+      labmaskfactor = resampleImage(labmaskfactor, subdim, useVoxels=1, interpType=as.numeric(asFactors) ) 
     }
-  else
-    {
-    stop("install the randomForest package")
+
+    # initialize output images for this subject
+    if (asFactors) { nprob = length(levels(rfm$y))
+    } else { nprob=1 }
+    masterprobs[[i]] = list()
+    for (t in 1:nprob) masterprobs[[i]][[t]] = labmaskfactor*0
+    ##
+    
+    
+    nchunks = round( sum(labmaskfactor!=0) / voxchunk )
+    if ( nchunks <= 2 ) nchunks=1
+    chunkmask = splitMask(labmaskfactor,nchunks)
+    for (ch in 1:nchunks) {
+      fm = matrix(nrow=sum(chunkmask==ch), ncol=neigh*nfeats) # initialize matrix to predict from
+      fromcol = tocol = 0 # reset this for the nfeats loop
+      binchunk = thresholdImage(chunkmask,ch,ch) # binary mask for this chunk only
+      
+      for ( k in 1:nfeats ) {
+        # which columns shall we fill
+        fromcol = tocol+1
+        tocol = fromcol + neigh - 1
+        
+        # get neighborhood
+        m1<-t(getNeighborhoodInMask( xfactor[[k]], binchunk, rad, spatial.info=F, boundary.condition='image' ))
+        
+        # make sure neiborhood is not out of image
+        if (any(is.na(m1)))
+          stop(paste('Neighborhood falling out of image for subject',i,'feature',k,'\n',
+                     'Consider padding the images with zero values to increase neighborhood availability.'))
+        
+        # put in fm
+        fm[, fromcol:tocol] = m1
+        invisible(gc())
+      }
+      
+      # predict this chunk
+      predtype<-'response'
+      if ( asFactors ) predtype<-'prob'
+      probs = t( predict( rfm ,newdata=fm, type=predtype) )
+      
+      # fill masterprobs of this subject
+      for (m in 1:nprob) masterprobs[[i]][[m]][binchunk==1] = probs[m,]
+      
+      rm(probs)
+      invisible(gc()) # clean up some memory
     }
+    
+    # create segmentation for this sub
+    if (asFactors) { 
+      temp = imageListToMatrix( unlist(masterprobs[[i]]) , labmaskfactor )
+      temp = apply( temp, FUN=which.max, MARGIN=2)
+      seg[[i]] = makeImage( labmaskfactor , temp )
+      rm(temp); invisible(gc())
+    } else {
+      response[i] = apply( imageListToMatrix( unlist(masterprobs) , labmaskfactor ), FUN=median, MARGIN=1 )
+    }
+  }
+  
+  # return either image segmentation or response
+  if ( asFactors ) {
+    return( list( seg=seg, probs=masterprobs ) )
+  } else {
+    return( list( seg=response, probs=masterprobs ) )
+  }
+}
+
+
+
+
+#' split a mask into n labeled sub-masks
+#'
+#' @param mask antsImage mask
+#' @param n number of mask chunks
+#' @return relabeledMask
+#' @author Avants BB, Tustison NJ
+#'
+#' @examples
+#' mask = getMask( antsImageRead( getANTsRData("r16" ) ) )
+#' smask = splitMask( mask, 10 )
+#'
+#' @export splitMask
+splitMask <- function( mask, n )
+{
+  # first compute chunk size
+  hasvalues = mask >= 0.5
+  nnz = sum( hasvalues )
+  voxchunk = round( nnz / n ) - 1
+  chunk.seq = seq(1, nnz, by=voxchunk )
+  chunk.seq[ length(chunk.seq) ] = nnz
+  smask = mask * 0
+  for ( ch in 1:( length(chunk.seq)-1 ) )
+  {
+    # set end of this chunk
+    chnxt = chunk.seq[ ch + 1 ] - 1
+    if ( ch ==  ( length(chunk.seq)-1 ) ) chnxt = nnz
+    # create mask for this chunk
+    temp = which( hasvalues, arr.ind=T )[ chunk.seq[ch]:chnxt ]
+    tnnz = hasvalues
+    tnnz[ -temp ] = FALSE
+    smask[ tnnz ] = ch
+  }
+  if ( sum( mask >= 0.5 ) != sum(smask >= 0.5 ) )
+  {
+    stop("submask non-zero entries should be the same as input mask" )
+  }
+  return( smask )
 }

--- a/R/vwnrfs.R
+++ b/R/vwnrfs.R
@@ -15,7 +15,7 @@
 #' @param asFactors boolean - treat the y entries as factors
 #' @return list a 4-list with the rf model, training vector, feature matrix
 #' and the random mask
-#' @author Avants BB, Tustison NJ
+#' @author Avants BB, Tustison NJ, Pustina D
 #'
 #' @examples
 #'

--- a/R/vwnrfs.R
+++ b/R/vwnrfs.R
@@ -89,7 +89,7 @@ vwnrfs <- function( y, x, labelmasks, rad=NA, nsamples=8,
   ulabs<-ulabs[ ulabs > 0 ]
   neigh = prod(rad*2+1) # neighborhood size we'll get from getNeighborhoodInMask
   nsubj = length(x) # number of subjects
-  nfeats = nfeats<-length(x[[1]]) # number of features
+  nfeats = length(x[[1]]) # number of features
   tv<-rep( NA, nsamples*length(ulabs)*nsubj )  # Y for random forest
   fm = matrix(nrow=length(tv) ,  ncol=neigh*nfeats )  # X for random forest
   


### PR DESCRIPTION
Added a new function to resample an image based with the same resolution and header as a target image. This resolves an error observed when downsampling an image and upsampling it back to the same size, which causes the voxels to be of slightly different size, causing some functions (i.e., labelStats) to see the images as occupying different physical spaces.