### PR TITLE
Coerce vectors to matrix in timeseries2matrix.R

### DIFF
--- a/R/timeseries2matrix.R
+++ b/R/timeseries2matrix.R
@@ -31,9 +31,9 @@ timeseries2matrix <- function(img, mask) {
   if (length(labs) == 1) 
     return(mat)
   maskvec <- mask[logmask]
-  mmat <- matrix(apply(mat[, maskvec == labs[1]], FUN = mean, MARGIN = 1), ncol = 1)
+  mmat <- matrix(apply(as.matrix(mat[, maskvec == labs[1]]), FUN = mean, MARGIN = 1), ncol = 1)
   for (i in 2:length(labs)) {
-    newmat <- matrix(apply(mat[, maskvec == labs[i]], FUN = mean, MARGIN = 1), 
+    newmat <- matrix(apply(as.matrix(mat[, maskvec == labs[i]]), FUN = mean, MARGIN = 1), 
       ncol = 1)
     mmat <- cbind(mmat, newmat)
   }


### PR DESCRIPTION
I was receiving the following error when processing functional data.
`Error in apply(mat[, maskvec == labs[1]], FUN = mean, MARGIN = 1) : 
  dim(X) must have a positive length`
I was following the functional processing instructions from https://github.com/stnava/ANTsR/blob/master/vignettes/RestingBOLD.Rmd
Anytime I called timeseries2matrix(img, mask) I was getting this error.
This change seems to fix the error by forcing vectors into a matrix, but doesn't affect when `mat[, maskvec == labs[i]]` already evaluates to a matrix.