### PR TITLE
save.ANTsR: full paths enabled, allows save-load-save; plot: fixed alpha

### DIFF
--- a/R/plot.antsImage.R
+++ b/R/plot.antsImage.R
@@ -453,6 +453,8 @@ if ( ! any( is.na( domainImageMap ) ) )
         space = "Lab")
     }
     heatvals <- colorfun(nlevels)
+    # fix to get alpha transparency correct
+    if (nchar(heatvals[1]) == 7 & alpha != 1) heatvals = paste0(heatvals,round(alpha*100,0))
     if (locthresh[1] > 1)
       heatvals[1:(locthresh[1] - 1)] <- NA
     if (locthresh[2] < (nlevels - 1)) {

--- a/R/save.ANTsR.R
+++ b/R/save.ANTsR.R
@@ -24,25 +24,26 @@
 #' }
 #' @rdname save.ANTsR
 #' @export
-
 save.ANTsR <- function(filename=file.path('.','.ANTsRsession'),
                        objects=NA,
                        env=as.environment(1),
                        overwrite=F, 
                        clonediskfiles=T,
                        ...) {
+  # convert to absolute path
+  filename = file.path(dirname(normalizePath(filename)),basename(filename))
   
   # create or empty the target folder
-  if (file.exists(file.path(filename,'temp.Rdata')) & overwrite ) {
+  if (file.exists(file.path(filename,'ANTSLOAD.Rdata')) & overwrite ) {
     fnames = list.files(filename)
-    drop = file.remove(file.path(filename,fnames) )
+    assign('fremove1234567890', file.path(filename,fnames) , envir = env)
   } else {
     dir.create(filename,showWarnings = F)
   }
-  if (file.exists(file.path(filename,'temp.Rdata')) & ! overwrite ){
+  if (file.exists(file.path(filename,'ANTSLOAD.Rdata')) & ! overwrite ){
     stop(paste('Folder', filename, 'not empty and overwrite is false.'))
   }
-    
+  
   
   antslist = as.list(env)
   if(all(!is.na(objects))) {
@@ -61,6 +62,15 @@ save.ANTsR <- function(filename=file.path('.','.ANTsRsession'),
   funimgSf = function(x,fold=filename) {
     index = which(file.exists(x))
     if (length(index) == 0) return(x)
+    
+    nocopy = file.exists(file.path(fold,basename(x[index])))
+    noremovef = file.path(fold,basename(x[index[nocopy]]))
+    noremoveindx = match(noremovef, fremove1234567890 )
+    assign('fremove1234567890', fremove1234567890[-(noremoveindx)], envir = env)
+    x[index[nocopy]] = paste0('ANTSrepl', basename(x[index[nocopy]]) )
+    index = index[! nocopy]
+    if (length(index) == 0) return(x)
+    
     for (indx in index) {      
       file = paste0(paste(sample(c(0:9, letters, LETTERS), 20, replace=T),collapse=''),
                     '_', basename(x[indx]))
@@ -71,9 +81,13 @@ save.ANTsR <- function(filename=file.path('.','.ANTsRsession'),
     return(x)
   }
   
-  temp = rapply(antslist, funimgSf, classes='character', how='replace')
-  temp = rapply(temp, funimgS, classes='antsImage', how='replace')
-  save(temp,file=file.path(filename,'temp.Rdata'), ...)
+  if (clonediskfiles) antslist = rapply(antslist, funimgSf, classes='character', how='replace')
+  ANTSLOAD = rapply(antslist, funimgS, classes='antsImage', how='replace')
+  
+  drop=file.remove(fremove1234567890) # cleanup remaining files in folder
+  rm(fremove1234567890,envir = env)
+  
+  save(ANTSLOAD,file=file.path(filename,'ANTSLOAD.Rdata'), ...)
   
 }
 
@@ -85,6 +99,8 @@ save.ANTsR <- function(filename=file.path('.','.ANTsRsession'),
 #' @export
 load.ANTsR <- function(filename=file.path('.','.ANTsRsession'),
                        env=as.environment(1)) {
+  # convert to absolute path
+  filename = file.path(dirname(normalizePath(filename)),basename(filename))
   
   funimgL = function(x,fold=filename) {
     if (length(x) == 1 && substr(x,1,8) == 'ANTSload') {
@@ -96,8 +112,8 @@ load.ANTsR <- function(filename=file.path('.','.ANTsRsession'),
     return(x)
   }
   
-  load(file.path(filename,'temp.Rdata'))
-  antslist = rapply(temp, funimgL, classes='character', how='replace')
+  load(file.path(filename,'ANTSLOAD.Rdata'))
+  antslist = rapply(ANTSLOAD, funimgL, classes='character', how='replace')
   envir = list2env(antslist, envir = env)
   
 }

--- a/R/save.ANTsR.R
+++ b/R/save.ANTsR.R
@@ -7,10 +7,9 @@
 #' @param env Environment to save from or load to.
 #' @param overwrite logical to select whether overwriting existing data is allowed.
 #' @param clonediskfiles logical enables the copying of disk files that are not loaded
-#'      in workspace but where character variables point. This enables a later 
-#'      re-instantiation of the full workspace including antsRegistration transformation
-#'      matrices. May need to be careful when saving the entire workspace with this option
-#'      set to true.
+#'      in workspace but where character variables point. Set to TRUE if moving sessions 
+#'      from one computer to another or if you save antsRegistration() outputs. Set to 
+#'      FALSE if you save temporary sessions to continue later on the same computer.
 #' @param ... Additional arguments to pass to \code{save}.
 #' 
 #' @author Pustina D


### PR DESCRIPTION

1. Now supports loading, manipulating and saving sessions in the same folder. Files are not copied if not necessary.
2. All filenames are converted to full paths when loaded, so the user can change working directory without affecting the manipulation of objects.
3. Fixed a bug that did not take in account clonediskfiles=F