### PR TITLE
Fix slice matrix dimensions in plot.antsImage

### DIFF
--- a/R/plot.antsImage.R
+++ b/R/plot.antsImage.R
@@ -264,10 +264,10 @@ if ( ! any( is.na( domainImageMap ) ) )
   if ( imagedim == 2 )
     slices <- 1
   nslices <- length(slices)
-  winrows <- round(length(slices) / ncolumns ) # controls number of rows
+  winrows <- ceiling(length(slices) / ncolumns ) # controls number of rows
   if (winrows < 1)
     winrows <- 1
-  wincols <- round(nslices/winrows) # controls number of rows
+  wincols <- ncolumns # controls number of columns
   if (length(slices) < wincols )
     wincols <- length(slices)
   reoSlice <- function( inimg )


### PR DESCRIPTION
In situations where:

```
winrows <- round(length(slices) / ncolumns) ## rounding down
wincols <- round(length(slices) / winrows)    ## rounding down
```

the product of winrows and wincols can be less than length(slices) causing an error.

Ex:

```
img <- makeImage(c(10,10,10), array(1:1000, dim = c(10,10,10)))
plot.antsImage(img, ncolumns = 4, slice = 1:9)
```

New code honours the user specified ncolumns ```wincols <- ncolumns``` and uses ceiling to compute the number of rows, this ensures sufficient space.