### PR TITLE
Updating antsAverageImages

### DIFF
--- a/R/antsAverageImages.R
+++ b/R/antsAverageImages.R
@@ -1,7 +1,7 @@
 #' Computes average of image list 
 #'
 #' Calculate the mean of a list of antsImages 
-#' @param imageList list of antsImages 
+#' @param imageList list of antsImages or a character vector of filenames
 #' @param normalize boolean determines if image is divided by mean before
 #' averaging
 #' @author Avants BB, Pustina D
@@ -10,15 +10,44 @@
 #' r64 <- antsImageRead(getANTsRData('r64'))
 #' mylist <- list(r16, r64)
 #' antsAverageImages(mylist)
-antsAverageImages <- function( imageList, normalize = FALSE )
+antsAverageImages <- function( imageList, normalize = FALSE)
   {
-  avg <- imageList[[1]] * 0
-  for ( i in imageList ) {
-    if ( normalize ) {
-      i <- i / mean( i )
+  
+  # determine if input is list of images or filenames
+  isfile = F
+  if (class(imageList) == 'character') {
+    if (any(!file.exists(imageList))) {
+      stop('One or more files do not exist.')
     }
-    avg <- avg + i
+    isfile = T
+  }
+  
+  # create empty average image
+  if (isfile) {
+    avg = antsImageRead(imageList[1])*0
+    masterdim = dim(avg)
+  } else {  
+    avg <- imageList[[1]] * 0
+  }
+  
+  # average them
+  for ( i in imageList ) {
+    
+    if (isfile) {
+      img = antsImageRead(i)
+      if ( any(dim(img) != masterdim) ) {
+           stop(paste('Different dimensions for', i))
+      }
+      invisible(gc()) # run garbage collection in case old img is not cleaned
+    } else {
+      img = i
+    }
+    
+    if ( normalize ) {
+      img <- img / mean( img )
+    }
+    avg <- avg + img
   }
   avg <- avg / length(imageList)
   return( avg )
-  }
+}

--- a/man/antsAverageImages.Rd
+++ b/man/antsAverageImages.Rd
@@ -7,7 +7,7 @@
 antsAverageImages(imageList, normalize = FALSE)
 }
 \arguments{
-\item{imageList}{list of antsImages}
+\item{imageList}{list of antsImages or a character vector of filenames}
 
 \item{normalize}{boolean determines if image is divided by mean before
 averaging}


### PR DESCRIPTION
Enabling `antsAverageImages` to get a vector of filenames. This allows averaging of images without loading them in memory. Useful when working on big data with hundreds of subjects. Function is backward compatible.