### PR TITLE
ENH: dimensional return from which

### DIFF
--- a/R/antsImage_class.R
+++ b/R/antsImage_class.R
@@ -919,14 +919,16 @@ setMethod(f = "==", signature(e1 = "antsImage"), definition = function(e1, e2) {
     if (class(e2$region) != "antsRegion") {
       stop("region argument not of class 'antsRegion'")
     }
-    return(.Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
-      PACKAGE = "ANTsR"))
+    x = .Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
+      PACKAGE = "ANTsR")
+    return( array(dim=dim(e1), data=x) )
   } else if ((class(e2) == "numeric" | class(e2) == "integer") && length(e2) == 1) {
     if(class(e2) == "integer")
       e2 <- as.numeric(e2)
     region <- new("antsRegion", index = integer(), size = integer())
-    return(.Call("antsImage_RelationalOperators", e1, e2, region,
-      operator, PACKAGE = "ANTsR"))
+    x = .Call("antsImage_RelationalOperators", e1, e2, region,
+      operator, PACKAGE = "ANTsR")
+    return( array(dim=dim(e1), data=x))
   } else {
     stop("rhs must be a scalar or a list( <scalar> , <antsRegion> )")
   }
@@ -943,11 +945,13 @@ setMethod(f = "!=", signature(e1 = "antsImage"), definition = function(e1, e2) {
     if (class(e2$region) != "antsRegion") {
       stop("region argument not of class 'antsRegion'")
     }
-    return(.Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
-      PACKAGE = "ANTsR"))
+    x = .Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
+      PACKAGE = "ANTsR")
+    return( array(dim=dim(e1), data=x) )
   } else if (class(e2) == "numeric" && length(e2) == 1) {
     region <- new("antsRegion", index = integer(), size = integer())
-    return(.Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR"))
+    x = .Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR")
+    return( array(dim=dim(e1), data=x))
   } else {
     stop("rhs must be a scalar or a list( <scalar> , <antsRegion> )")
   }
@@ -963,11 +967,13 @@ setMethod(f = "<=", signature(e1 = "antsImage"), definition = function(e1, e2) {
     if (class(e2$region) != "antsRegion") {
       stop("region argument not of class 'antsRegion'")
     }
-    return(.Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
-      PACKAGE = "ANTsR"))
+    x = .Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
+      PACKAGE = "ANTsR")
+    return( array(dim=dim(e1), data=x))
   } else if (class(e2) == "numeric" && length(e2) == 1) {
     region <- new("antsRegion", index = integer(), size = integer())
-    return(.Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR"))
+    x = .Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR")
+    return( array(dim=dim(e1), data=x))
   } else {
     stop("rhs must be a scalar or a list( <scalar> , <antsRegion> )")
   }
@@ -983,11 +989,13 @@ setMethod(f = ">=", signature(e1 = "antsImage"), definition = function(e1, e2) {
     if (class(e2$region) != "antsRegion") {
       stop("region argument not of class 'antsRegion'")
     }
-    return(.Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
-      PACKAGE = "ANTsR"))
+    x = .Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
+      PACKAGE = "ANTsR")
+    return( array(dim=dim(e1), data=x))
   } else if (class(e2) == "numeric" && length(e2) == 1) {
     region <- new("antsRegion", index = integer(), size = integer())
-    return(.Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR"))
+    x = .Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR")
+    return( array(dim=dim(e1), data=x))
   } else {
     stop("rhs must be a scalar or a list( <scalar> , <antsRegion> )")
   }
@@ -1003,11 +1011,13 @@ setMethod(f = "<", signature(e1 = "antsImage"), definition = function(e1, e2) {
     if (class(e2$region) != "antsRegion") {
       stop("region argument not of class 'antsRegion'")
     }
-    return(.Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
-      PACKAGE = "ANTsR"))
+    x=.Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
+      PACKAGE = "ANTsR")
+    return(array(dim=dim(e1), data=x))
   } else if (class(e2) == "numeric" && length(e2) == 1) {
     region <- new("antsRegion", index = integer(), size = integer())
-    return(.Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR"))
+    x=.Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR")
+    return(array(dim=dim(e1), data=x))
   } else {
     stop("rhs must be a scalar or a list( <scalar> , <antsRegion> )")
   }
@@ -1023,11 +1033,13 @@ setMethod(f = ">", signature(e1 = "antsImage"), definition = function(e1, e2) {
     if (class(e2$region) != "antsRegion") {
       stop("region argument not of class 'antsRegion'")
     }
-    return(.Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
-      PACKAGE = "ANTsR"))
+    x =.Call("antsImage_RelationalOperators", e1, e2$value, e2$region, operator,
+      PACKAGE = "ANTsR")
+    return( array(dim=dim(e1), data=x))
   } else if (class(e2) == "numeric" && length(e2) == 1) {
     region <- new("antsRegion", index = integer(), size = integer())
-    return(.Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR"))
+    x=.Call("antsImage_RelationalOperators", e1, e2, region, operator, PACKAGE = "ANTsR")
+    return(array(dim=dim(e1), data=x))
   } else {
     stop("rhs must be a scalar or a list( <scalar> , <antsRegion> )")
   }


### PR DESCRIPTION
The current implementation of image relational operators applied to an antsImage ( e.g. maskImg > 0 ) always return a 1D vector, unlike the same operation on an array which returns a boolean array of the same size and dimension as the input array, thus providing the ability to get the indices of the locations via "indices = which( myArray > 0, arr.ind=T )"  The changes here resize the returned vector to equal the dimensions of the input image so voxel indices can be obtained via "which( maskImage > 0, arr.ind=T )" Since these arrays can also be indexed as 1D vectors, this shouldn't be problematic for existing code.