### PR TITLE
Updated using the new travis.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,40 +50,9 @@ before_install:
     sh cmake.sh --skip-license --prefix=${HOME};
     fi
   - export PATH=$HOME/bin/:$PATH
-  - Rscript -e 'if (!requireNamespace("devtools", quietly = TRUE)) install.packages("devtools")'
-  - itkrrel=0.0.1
-  - gh_binary_install ITKR stnava ${itkrrel} latest
-  - gh_user=stnava
-  - ANTsRCorerel=latest
-  - reldir=0.3.4
-  - gh_binary_install ANTsRCore ${gh_user} ${ANTsRCorerel} ${reldir}
-  # - basedir=${PWD}
-  # - cd ..
-  # - cd $basedir
-  # - cd ~/
-  # - Rscript -e 'if (!"Rcpp" %in% rownames(installed.packages())) install.packages("Rcpp", dependencies = TRUE)'
-  # - Rscript -e 'if (!"devtools" %in% rownames(installed.packages())) install.packages("devtools", dependencies = TRUE)'
-  # - itkrrel=0.0.1
-  # - if [ "$TRAVIS_OS_NAME" == "linux" ];
-  #   then wget -O ITKR.tar.gz https://github.com/stnava/ITKR/releases/download/latest/ITKR_${itkrrel}_R_x86_64-pc-linux-gnu.tar.gz;
-  #   R CMD INSTALL ITKR.tar.gz; fi
-  # - if [ "$TRAVIS_OS_NAME" == "osx" ];
-  #   then wget -O ITKR.tgz http://github.com/stnava/ITKR/releases/download/latest/ITKR_${itkrrel}.tgz;
-  #   R CMD INSTALL ITKR.tgz; fi
-  # - Rscript -e 'p = c("RcppEigen", "magrittr"); p = setdiff(p, installed.packages()); if (length(p)) install.packages(p);'
-  # - gh_user=stnava
-  # - ANTsRCorerel=0.2
-  # - reldir=latest
-  # - if [ "$TRAVIS_OS_NAME" == "linux" ];
-  #   then wget -O ANTsRCore.tar.gz https://github.com/${gh_user}/ANTsRCore/releases/download/${reldir}/ANTsRCore_${ANTsRCorerel}_R_x86_64-pc-linux-gnu.tar.gz;
-  #   R CMD INSTALL ANTsRCore.tar.gz; fi
-  # - if [ "$TRAVIS_OS_NAME" == "osx" ];
-  #   then wget -O ANTsRCore.tgz http://github.com/${gh_user}/ANTsRCore/releases/download/${reldir}/ANTsRCore_${ANTsRCorerel}.tgz;
-  #   R CMD INSTALL ANTsRCore.tgz; fi
-  # - cd ${basedir}
-  # # removing remotes
-  # - Rscript -e 'devtools::source_url("https://gist.githubusercontent.com/muschellij2/69c48f469ab34cc05752361645ffa8e0/raw/57e7d3b22907699d260f863a0d337a12567ffc30/rewrite_dcf.R"); rewrite_dcf(drop_remotes = c("ANTsRCore", "ITKR"));'
-
+  - remote_binary_install ITKR ANTsRCore
+  - install_remotes_no_dep
+  
 # Build and check package
 script:
   - source ~/.R/Makevars

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ANTsR
 Type: Package
 Title: ANTs in R: Quantification Tools for Biomedical Images
-Version: 0.5.6
+Version: 0.6
 Date: 2017-06-06
 Author: Brian B. Avants, Benjamin M. Kandel, Jeff T. Duda, Philip A. Cook,
     Nicholas J. Tustison, Shrinidhi KL


### PR DESCRIPTION
See https://github.com/muschellij2/ghtravis for some of the functions.  Mainly the `install_remote_binaries` function executes the latest (with respect to creating date) installation of the binary packages.